### PR TITLE
Make settings and wallet account-specific

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -801,6 +801,7 @@ Future<void> main() async {
     String priv = generatePrivateKey();
     await settingProvider.addAndChangeKey(priv, true, false, updateUI: false);
     String publicKey = getPublicKey(priv);
+    await settingProvider.activateAccountSettings(publicKey, updateUI: false);
     ndk.accounts.loginPrivateKey(pubkey: publicKey, privkey: priv);
   }
   if (loggedUserSigner != null) {
@@ -810,7 +811,7 @@ Future<void> main() async {
     });
   }
   if (AppFeatures.enableWallet) {
-    nwcProvider?.init(); // Use null-aware access
+    await nwcProvider?.init(); // Use null-aware access
   }
 
   AppFeatures.printActiveFeatures(); // Optional: Print features for this flavor
@@ -1284,6 +1285,8 @@ class _MyApp extends State<MyApp>
             await settingProvider.addAndChangeKey(priv, true, false,
                 updateUI: false);
             String publicKey = getPublicKey(priv);
+            await settingProvider.activateAccountSettings(publicKey,
+                updateUI: false);
             ndk.accounts.loginPrivateKey(pubkey: publicKey, privkey: priv);
 
             await initRelays(newKey: true);

--- a/lib/provider/nwc_provider.dart
+++ b/lib/provider/nwc_provider.dart
@@ -16,6 +16,7 @@ class NwcProvider extends ChangeNotifier {
   static const int BTC_IN_SATS = 100000000;
 
   NwcConnection? connection;
+  String? connectedNwcUri;
 
   GetBalanceResponse? cachedBalanceResponse;
   ListTransactionsResponse? cachedListTransactionsResponse;
@@ -37,8 +38,15 @@ class NwcProvider extends ChangeNotifier {
 
   Future<void> init() async {
     String? uri = await settingProvider.getNwc();
-    if (StringUtil.isNotBlank(uri) && connection == null) {
-      await connect(uri!, doGetInfo: false);
+    if (StringUtil.isBlank(uri)) {
+      await _disconnectConnection();
+      return;
+    }
+
+    String normalizedUri = _normalizeNwcUri(uri!);
+    if (connection == null || connectedNwcUri != normalizedUri) {
+      await _disconnectConnection();
+      await connect(normalizedUri, doGetInfo: false);
     }
   }
 
@@ -66,7 +74,7 @@ class NwcProvider extends ChangeNotifier {
       {Function(String?)? onConnect,
       Function(String?)? onError,
       bool? doGetInfo = true}) async {
-    nwc = nwc.replaceAll("yana:", "nostr+walletconnect:");
+    nwc = _normalizeNwcUri(nwc);
     await ndk.nwc
         .connect(nwc,
             doGetInfoMethod: doGetInfo!,
@@ -76,7 +84,8 @@ class NwcProvider extends ChangeNotifier {
             onError: onError)
         .then((connection) async {
       this.connection = connection;
-      settingProvider.setNwc(nwc);
+      connectedNwcUri = nwc;
+      await settingProvider.setNwc(nwc);
       await refreshWallet();
       if (onConnect != null) {
         onConnect.call(connection.uri.lud16);
@@ -129,10 +138,19 @@ class NwcProvider extends ChangeNotifier {
   /// disconnect the wallet
   Future<void> disconnect() async {
     await settingProvider.setNwc(null);
+    await _disconnectConnection();
+  }
+
+  String _normalizeNwcUri(String nwc) {
+    return nwc.replaceAll("yana:", "nostr+walletconnect:");
+  }
+
+  Future<void> _disconnectConnection() async {
     if (connection != null) {
       await ndk.nwc.disconnect(connection!);
       connection = null;
     }
+    connectedNwcUri = null;
     cachedBalanceResponse = null;
     cachedListTransactionsResponse = null;
     notifyListeners();

--- a/lib/provider/setting_provider.dart
+++ b/lib/provider/setting_provider.dart
@@ -8,6 +8,7 @@ import 'package:yana/models/video_autoplay_preference.dart';
 import 'package:yana/utils/platform_util.dart';
 
 import '../main.dart';
+import '../nostr/client_utils/keys.dart';
 import '../utils/base.dart';
 import '../utils/base_consts.dart';
 import '../utils/theme_style.dart';
@@ -45,12 +46,19 @@ class SettingProvider extends ChangeNotifier {
   final String IS_EXTERNAL_SIGNER_MAP = "keys_is_external_map";
   final String NWC_URI = "nwc_uri";
   final String NWC_SECRET = "nwc_secret";
+  final String ACCOUNT_SETTING_MIGRATED = "account_setting_migrated";
+  final String ACCOUNT_SETTING_PREFIX = "account_setting_";
+  final String NWC_URI_ACCOUNT_MIGRATED = "nwc_uri_account_migrated";
+  final String NWC_SECRET_ACCOUNT_MIGRATED = "nwc_secret_account_migrated";
+
+  String? _activeAccountPublicKey;
 
   static Future<SettingProvider> getInstance() async {
     if (_settingProvider == null) {
       _settingProvider = SettingProvider();
       _settingProvider!._sharedPreferences = await DataUtil.getInstance();
       await _settingProvider!._init();
+      await _settingProvider!._activateCurrentAccountSettings(updateUI: false);
       _settingProvider!._reloadTranslateSourceArgs();
     }
     return _settingProvider!;
@@ -103,6 +111,7 @@ class SettingProvider extends ChangeNotifier {
 
   Future<void> reload() async {
     await _init();
+    await _settingProvider!._activateCurrentAccountSettings(updateUI: false);
     _settingProvider!._reloadTranslateSourceArgs();
     notifyListeners();
   }
@@ -139,6 +148,76 @@ class SettingProvider extends ChangeNotifier {
     return _keyIsPrivateMap[index.toString()] ?? false;
   }
 
+  String? publicKeyForIndex(int? index) {
+    if (index == null) {
+      return null;
+    }
+
+    String? key = _keyMap[index.toString()];
+    if (StringUtil.isBlank(key)) {
+      return null;
+    }
+
+    if (isPrivateKeyIndex(index)) {
+      try {
+        return getPublicKey(key!);
+      } catch (e) {
+        log("Unable to derive public key for account settings");
+        log(e.toString());
+        return null;
+      }
+    }
+
+    return key;
+  }
+
+  String? get currentPublicKey =>
+      publicKeyForIndex(_settingData?.privateKeyIndex);
+
+  String _accountSettingKey(String publicKey) {
+    return "$ACCOUNT_SETTING_PREFIX$publicKey";
+  }
+
+  String _accountSecureStorageKey(String storageKey, String publicKey) {
+    return "${storageKey}_$publicKey";
+  }
+
+  Future<void> _activateCurrentAccountSettings({bool updateUI = true}) async {
+    String? publicKey = currentPublicKey;
+    if (StringUtil.isBlank(publicKey)) {
+      return;
+    }
+
+    await activateAccountSettings(publicKey!, updateUI: updateUI);
+  }
+
+  Future<void> activateAccountSettings(String publicKey,
+      {bool updateUI = true}) async {
+    int? privateKeyIndex = _settingData!.privateKeyIndex;
+    String accountSettingKey = _accountSettingKey(publicKey);
+    String? accountSettingStr =
+        _sharedPreferences!.getString(accountSettingKey);
+    SettingData accountSetting;
+
+    if (StringUtil.isNotBlank(accountSettingStr)) {
+      accountSetting = SettingData.fromJson(json.decode(accountSettingStr!));
+    } else {
+      bool migrated =
+          _sharedPreferences!.getBool(ACCOUNT_SETTING_MIGRATED) ?? false;
+      if (migrated) {
+        accountSetting = SettingData();
+      } else {
+        accountSetting = SettingData.fromJson(_settingData!.toJson());
+        await _sharedPreferences!.setBool(ACCOUNT_SETTING_MIGRATED, true);
+      }
+    }
+
+    accountSetting.privateKeyIndex = privateKeyIndex;
+    _settingData = accountSetting;
+    _activeAccountPublicKey = publicKey;
+    await saveAndNotifyListeners(updateUI: updateUI);
+  }
+
   Future<int> addAndChangeKey(String key, bool isPrivate, bool isExternalSigner,
       {bool updateUI = false}) async {
     int? findIndex;
@@ -170,7 +249,7 @@ class SettingProvider extends ChangeNotifier {
         await secureStorage.write(
             key: IS_EXTERNAL_SIGNER_MAP,
             value: json.encode(_keyIsExternalSignerMap));
-        saveAndNotifyListeners(updateUI: updateUI);
+        await saveAndNotifyListeners(updateUI: updateUI);
 
         return i;
       }
@@ -180,19 +259,70 @@ class SettingProvider extends ChangeNotifier {
   }
 
   Future<String?> getNwc() async {
-    return await secureStorage.read(key: NWC_URI);
+    return await _readAccountSecureStorage(NWC_URI, NWC_URI_ACCOUNT_MIGRATED);
   }
 
   Future<void> setNwc(String? uri) async {
-    await secureStorage.write(key: NWC_URI, value: uri);
+    await _writeAccountSecureStorage(NWC_URI, NWC_URI_ACCOUNT_MIGRATED, uri);
   }
 
   Future<String?> getNwcSecret() async {
-    return await secureStorage.read(key: NWC_SECRET);
+    return await _readAccountSecureStorage(
+        NWC_SECRET, NWC_SECRET_ACCOUNT_MIGRATED);
   }
 
   Future<void> setNwcSecret(String? secret) async {
-    await secureStorage.write(key: NWC_SECRET, value: secret);
+    await _writeAccountSecureStorage(
+        NWC_SECRET, NWC_SECRET_ACCOUNT_MIGRATED, secret);
+  }
+
+  Future<String?> _readAccountSecureStorage(
+      String storageKey, String migrationKey) async {
+    String? publicKey = currentPublicKey ?? _activeAccountPublicKey;
+    if (StringUtil.isBlank(publicKey)) {
+      return await secureStorage.read(key: storageKey);
+    }
+
+    String accountStorageKey = _accountSecureStorageKey(storageKey, publicKey!);
+    String? accountValue = await secureStorage.read(key: accountStorageKey);
+    if (StringUtil.isNotBlank(accountValue)) {
+      return accountValue;
+    }
+
+    bool migrated = _sharedPreferences!.getBool(migrationKey) ?? false;
+    if (migrated) {
+      return null;
+    }
+
+    String? legacyValue = await secureStorage.read(key: storageKey);
+    await _sharedPreferences!.setBool(migrationKey, true);
+    if (StringUtil.isBlank(legacyValue)) {
+      return null;
+    }
+
+    await secureStorage.write(key: accountStorageKey, value: legacyValue);
+    return legacyValue;
+  }
+
+  Future<void> _writeAccountSecureStorage(
+      String storageKey, String migrationKey, String? value) async {
+    String? publicKey = currentPublicKey ?? _activeAccountPublicKey;
+    if (StringUtil.isBlank(publicKey)) {
+      await _writeSecureStorage(storageKey, value);
+      return;
+    }
+
+    await _sharedPreferences!.setBool(migrationKey, true);
+    await _writeSecureStorage(
+        _accountSecureStorageKey(storageKey, publicKey!), value);
+  }
+
+  Future<void> _writeSecureStorage(String storageKey, String? value) async {
+    if (value == null) {
+      await secureStorage.delete(key: storageKey);
+    } else {
+      await secureStorage.write(key: storageKey, value: value);
+    }
   }
 
   void removeKey(int index) {
@@ -524,6 +654,11 @@ class SettingProvider extends ChangeNotifier {
     var jsonStr = json.encode(m);
     // print(jsonStr);
     await _sharedPreferences!.setString(DataKey.SETTING, jsonStr);
+    if (_activeAccountPublicKey != null &&
+        currentPublicKey == _activeAccountPublicKey) {
+      await _sharedPreferences!.setString(
+          _accountSettingKey(_activeAccountPublicKey!), jsonStr);
+    }
     _settingProvider!._reloadTranslateSourceArgs();
 
     if (updateUI) {

--- a/lib/router/index/account_manager_component.dart
+++ b/lib/router/index/account_manager_component.dart
@@ -56,8 +56,8 @@ class AccountsState extends State<AccountsComponent> {
         publicKey: !isPrivate ? value : null,
         isCurrent: _settingProvider.privateKeyIndex == index,
         onLoginTap: onLoginTap,
-        onLogoutTap: (index) {
-          AccountsState.onLogoutTap(index, context: context);
+        onLogoutTap: (index) async {
+          await AccountsState.onLogoutTap(index, context: context);
         },
       ));
     });
@@ -212,6 +212,7 @@ class AccountsState extends State<AccountsComponent> {
     } else {
       ndk.accounts.loginExternalSigner(signer: eventSigner);
     }
+    await settingProvider.activateAccountSettings(publicKey);
 
     followEventProvider?.clear();
     await followEventProvider?.loadCachedFeed();
@@ -222,19 +223,19 @@ class AccountsState extends State<AccountsComponent> {
       notificationsProvider?.notifyListeners();
     }
     if (AppFeatures.enableWallet) {
-      nwcProvider?.init();
+      await nwcProvider?.init();
     }
     // settingProvider.notifyListeners(); // This line seems to be duplicated, removing one
     EasyLoading.dismiss();
   }
 
-  static void onLogoutTap(int index,
-      {bool routerBack = true, required BuildContext context}) {
+  static Future<void> onLogoutTap(int index,
+      {bool routerBack = true, required BuildContext context}) async {
     var oldIndex = settingProvider.privateKeyIndex;
-    clearLocalData(index);
-    if (AppFeatures.enableWallet) {
-      nwcProvider?.disconnect();
+    if (oldIndex == index && AppFeatures.enableWallet) {
+      await nwcProvider?.disconnect();
     }
+    clearLocalData(index);
     if (oldIndex == index) {
       clearCurrentMemInfo();
       ndk.requests.closeAllSubscription();

--- a/lib/router/index/index_drawer_content.dart
+++ b/lib/router/index/index_drawer_content.dart
@@ -281,7 +281,8 @@ class _IndexDrawerContentComponnent extends State<IndexDrawerContentComponent> {
                       onTap: () async {
                         var index = settingProvider.privateKeyIndex;
                         if (index != null) {
-                          AccountsState.onLogoutTap(index, routerBack: true, context: context);
+                          await AccountsState.onLogoutTap(index,
+                              routerBack: true, context: context);
                         }
                       },
                     ),

--- a/lib/router/setting/setting_router.dart
+++ b/lib/router/setting/setting_router.dart
@@ -680,7 +680,7 @@ class _SettingRouter extends State<SettingRouter> with WhenStopFunction {
         if (result == true) {
           var index = settingProvider.privateKeyIndex;
           if (index != null) {
-            AccountsState.onLogoutTap(index,
+            await AccountsState.onLogoutTap(index,
                 routerBack: true, context: context);
             metadataProvider.clear();
           } else {

--- a/lib/ui/user/metadata_top_component.dart
+++ b/lib/ui/user/metadata_top_component.dart
@@ -383,10 +383,12 @@ class _MetadataTopComponent extends State<MetadataTopComponent> {
                 }
                 followEventProvider?.clear();
                 followNewEventProvider?.clear();
-                settingProvider.addAndChangeKey(widget.pubkey, false, false,
+                await settingProvider.addAndChangeKey(
+                    widget.pubkey, false, false,
                     updateUI: true);
                 String publicKey = widget.pubkey;
                 ndk.accounts.loginPublicKey(pubkey: publicKey);
+                await settingProvider.activateAccountSettings(publicKey);
                 // ndk = Ndk(
                 //     NdkConfig(
                 //       eventVerifier: eventVerifier,
@@ -396,7 +398,7 @@ class _MetadataTopComponent extends State<MetadataTopComponent> {
                 //     ));
                 await initRelays(newKey: false);
                 followEventProvider?.loadCachedFeed();
-                nwcProvider?.init();
+                await nwcProvider?.init();
                 settingProvider.notifyListeners();
                 EasyLoading.dismiss();
                 context.pop();

--- a/lib/utils/base.dart
+++ b/lib/utils/base.dart
@@ -55,6 +55,7 @@ Future<void> doLogin(
                 privateKey: isPrivate ? key : null, publicKey: publicKey)
             : Nip07EventSigner(await js.getPublicKeyAsync());
     ndk.accounts.loginExternalSigner(signer: eventSigner);
+    await settingProvider.activateAccountSettings(publicKey, updateUI: false);
 
     await initRelayManager(isPublic ? key : getPublicKey(key), newKey);
   } catch (e) {
@@ -71,7 +72,7 @@ Future<void> initRelayManager(String publicKey, bool newKey) async {
       maskType: EasyLoadingMaskType.black);
   followEventProvider?.loadCachedFeed();
   if (AppFeatures.enableWallet) {
-    nwcProvider?.init();
+    await nwcProvider?.init();
   }
   settingProvider.notifyListeners();
   await EasyLoading.dismiss();


### PR DESCRIPTION
Fixes #80.

## Summary
- Store settings per account public key, with a one-time migration that preserves the existing global settings for the current account after upgrade.
- Store NWC URI/secret per account public key, with one-time migration from the legacy global secure-storage keys.
- Reload active account settings and reconnect/disconnect the NWC provider when users log in, switch accounts, create an account, or log out.

## Validation
- Ran: `git diff --check`
- Not run: `flutter analyze` / tests because this environment does not have `flutter` or `dart` installed.

Bounty payout BTC address: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`. If you need a Lightning invoice instead, please let me know.